### PR TITLE
Hotfix: Add error handling for when a user edits an event to have the maximum partipants allowed for an event lower than the actual number of participants

### DIFF
--- a/src/components/MyEvents.js
+++ b/src/components/MyEvents.js
@@ -104,6 +104,9 @@ const MyEvents = () => {
         setEventLocationErrorText('');
     }
 
+    const [eventCurrentParticipants, setEventCurrentParticipants] = React.useState('');
+    const [eventCurrentParticipantsError, setEventCurrentParticipantsError] = React.useState(false);
+
     const [eventParticipants, setEventParticipants] = React.useState('');
     const [eventParticipantsError, setEventParticipantsError] = React.useState('');
     const [eventParticipantsErrorText, setEventParticipantsErrorText] = React.useState(''); //ERROR EDITING IN RETURN BRACKETS
@@ -146,6 +149,9 @@ const MyEvents = () => {
         setEventLocation(event.location);
         setEventLocationError(false);
         setEventLocationErrorText('');
+
+        // Update event current participants
+        setEventCurrentParticipants(event.participants);
 
         // Update event participants
         setEventParticipants(parseInt(event.totalParticipants));
@@ -299,9 +305,15 @@ const MyEvents = () => {
         } else if (eventParticipants === '') {
             setEventParticipantsError(true);
             setEventParticipantsErrorText('Please enter a valid number of maximum participants.');
-            return false
+            return false;
+        } else if (eventParticipants < eventCurrentParticipants) {
+            setEventCurrentParticipantsError(true);
+            setTimeout(() => {
+                setEventCurrentParticipantsError(false);
+            }, 10000);
         } else {
             CallApiEditEvent();
+            setEventCurrentParticipantsError(false);
             setShowEditAlertMessage(true);
             setTimeout(() => {
                 window.location.reload();
@@ -424,6 +436,14 @@ const MyEvents = () => {
             {showEditAlertMessage && (
                 <Alert severity="success">
                     Event successfully edited.
+                </Alert>
+            )}
+
+            {eventCurrentParticipantsError && (
+                <Alert severity="error">
+                    You cannot set the maximum number of participants lower than your
+                    current number of participants. This event currently has {eventCurrentParticipants}
+                    &nbsp;participants.
                 </Alert>
             )}
         </div >


### PR DESCRIPTION
<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Added error handling for specific edge case where `totalParticipants` < `participants`.


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Edit an event which more than one participant (you can join one of your own events). 
2. Set the maximum participants value less than the current value for the participants. 
3. Verify that a toast message appears indicating that this is not allowed, and displays the current number of participants for the event.
4. Verify that setting a value larger than the current number of participants displays a success toast message and edits the event.