### PR TITLE
Users can no longer comment on Archived forums

### DIFF
--- a/routes/forums/getForums.js
+++ b/routes/forums/getForums.js
@@ -9,7 +9,7 @@ router.get('/api/getForums', (req, res) => {
 	let connection = mysql.createConnection(config);
 
 	let sql = 
-	`SELECT CONCAT(firstName, " ", lastName) AS creatorName, forumTitle, forums.description, forums.dateTime, forums.id
+	`SELECT CONCAT(firstName, " ", lastName) AS creatorName, forumTitle, forums.description, forums.dateTime, forums.id, forums.status
     FROM forums, users
     WHERE creatorID = users.id;`; 
 	

--- a/src/components/Forum.js
+++ b/src/components/Forum.js
@@ -213,10 +213,13 @@ const Forum = () => {
                             <Typography sx={{ mb: 1.5 }} color="text.secondary">
                                 Posted on {new Date(event.dateTime).toLocaleDateString()} by {event.creatorName}<br />
                             </Typography>
+                            <Typography variant="subtitle2" sx={{ mb: 1.5 }} color="text.secondary">
+                                Status: {event.status}<br />
+                            </Typography>
                             <Typography sx={{ mb: 1.5 }} color="text.secondary">
                                 <br />{event.description}<br />
                             </Typography>
-                            <form onSubmit={handleApiAddComment}>
+                            {event.status === "Active" && <form onSubmit={handleApiAddComment}>
                                 <TextField
                                     style={{ mb: 1.5, width: '350px' }}
                                     label="Add a comment"
@@ -224,7 +227,7 @@ const Forum = () => {
                                     onChange={handleNewComment}
                                 />
                                 <Button type="submit" style={{ color: "white", backgroundColor: "seagreen", mb: 1.5 }}>Submit</Button>
-                            </form>
+                            </form>}
                             <Typography sx={{ mb: 1.5 }} variant="h6" color="text.secondary">
                                 <br />Comments:<br />
                             </Typography>

--- a/src/components/Forums.js
+++ b/src/components/Forums.js
@@ -109,7 +109,7 @@ const Forums = () => {
                     </Link>
                     <Typography sx={{ mb: 1.5 }} color="text.secondary">
                         Posted on {new Date(new Date(forum.dateTime).getTime() - (5 * 60 * 60 * 1000)).toLocaleDateString()}<br />
-                        &nbsp; by {forum.creatorName}<br />
+                        by {forum.creatorName}<br />
                     </Typography>
                     <Typography variant="subtitle2" sx={{ mb: 1.5 }} color="text.secondary">
                                 Status: {forum.status}<br />

--- a/src/components/Forums.js
+++ b/src/components/Forums.js
@@ -111,6 +111,9 @@ const Forums = () => {
                         Posted on {new Date(new Date(forum.dateTime).getTime() - (5 * 60 * 60 * 1000)).toLocaleDateString()}<br />
                         &nbsp; by {forum.creatorName}<br />
                     </Typography>
+                    <Typography variant="subtitle2" sx={{ mb: 1.5 }} color="text.secondary">
+                                Status: {forum.status}<br />
+                            </Typography>
                     <Typography sx={{ mb: 1.5 }} color="text.secondary">
                         <br />{forum.description}<br />
                     </Typography>


### PR DESCRIPTION
## Trello ticket link
[As a user, I can archive my forum so that other users can no longer add comments.](https://trello.com/c/6cnSSEzD/33-as-a-user-i-can-archive-my-forum-so-that-other-users-can-no-longer-add-comments)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Users can no longer comment on Archived posts
* Posts will display a status message, if it is active or archived 


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Please go to http://localhost:3000/forums
2. Please click on an archived post
3. Please ensure you cannot post a comment
4. Please click on an active post
5. Please ensure you can post a comment
6. Please double-check that you can view the status of a forum on the main page and when you click on it


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Commenting on forums 