### PR TITLE
Hotfix: fix routing to pages only accessible by users logged in

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -30,18 +30,18 @@ function App() {
         <Router>
           <AuthProvider>
             <Switch>
-              {/* Landing Page */}
+              {/* Landing Pags */}
               <PrivateRoute exact path="/" component={Dashboard} />
+
+              {/* Authentication Pages */}
+              <Route path="/signup" component={Signup} />
+              <Route path="/login" component={Login} />
+              <Route path="/forgot-password" component={ForgotPassword} />
 
               {/* Settings Page */}
               <PrivateRoute path="/user-settings" component={UserSettings} />
               <PrivateRoute path="/update-credentials" component={UpdateCredentials} />
               <PrivateRoute path="/update-status" component={UpdateStatus} />
-              <Route path="/signup" component={Signup} />
-              <Route path="/login" component={Login} />
-              <Route path="/forgot-password" component={ForgotPassword} />
-              <Route path="/events" component={Events} />
-              <Route path="/create-event" component={CreateEvent} />
               <PrivateRoute path="/my-profile" component={ProfileDashboard} />
 
               {/* Event Pages */}
@@ -50,9 +50,9 @@ function App() {
               <PrivateRoute path="/my-events" component={MyEvents} />
 
               {/* Forum Pages */}
-              <Route path="/create-forum" component={CreateForum} />
-              <Route path="/forums" component={Forums} />
-              <Route path="/my-forums" component={MyForums} />
+              <PrivateRoute path="/create-forum" component={CreateForum} />
+              <PrivateRoute path="/forums" component={Forums} />
+              <PrivateRoute path="/my-forums" component={MyForums} />
               <PrivateRoute path="/forum/:forumID" component={Forum} />
             </Switch>
           </AuthProvider>

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -30,7 +30,7 @@ function App() {
         <Router>
           <AuthProvider>
             <Switch>
-              {/* Landing Pags */}
+              {/* Landing Page */}
               <PrivateRoute exact path="/" component={Dashboard} />
 
               {/* Authentication Pages */}


### PR DESCRIPTION
<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Some pages were accessible without the user being logged in, for these pages, the user is required to be logged in or they'll be redirected to the login page.


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Verify the following pages can only be accessed while logged in: "Create Forum", "Forums", My Forums".
2. Remove duplicate event pages