### PR TITLE
Hotfix: Fix Profile Box Position

### DIFF
--- a/src/components/userNetwork/NetworkProfile.js
+++ b/src/components/userNetwork/NetworkProfile.js
@@ -219,14 +219,7 @@ const NetworkProfile = () => {
         <>
             <NavigationBar></NavigationBar>
 
-            <Box
-                p="6"
-                width="800px"
-                position="absolute"
-                top="40%"
-                left="50%"
-                transform="translate(-50%, -50%)"
-            >
+            <Box sx={{ position: 'absolute', top: 115, left: '50%', width: 800, transform: 'translateX(-50%)' }}>
                 <Card>
                     <Center>
                         <Avatar

--- a/src/components/users/ProfileDashboard.js
+++ b/src/components/users/ProfileDashboard.js
@@ -289,14 +289,7 @@ const ProfileDashboard = () => {
     return (
         <>
             <NavigationBar></NavigationBar>
-            <Box
-                p="6"
-                width="800px"
-                position="absolute"
-                top="40%"
-                left="50%"
-                transform="translate(-50%, -50%)"
-            >
+            <Box sx={{ position: 'absolute', top: 115, left: '50%', width: 800, transform: 'translateX(-50%)' }}>
                 <Card>
                     <Center>
                         <Avatar


### PR DESCRIPTION
<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* On smaller screens, the profile box would render right below the nav bar, leaving no margin in between. 
![image](https://user-images.githubusercontent.com/57375371/227803525-ce7cd378-1c2b-4543-8cdc-38e7d72c03c6.png)


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Verify a notable gap exists between the nav bar and profile box.

