### PR TITLE
Hotfix: Fix position for Titles on Requests Page

### DIFF
--- a/src/components/users/Requests.js
+++ b/src/components/users/Requests.js
@@ -117,11 +117,13 @@ const Requests = () => {
 
             <NavigationBar></NavigationBar>
 
-            <Box marginTop="90px">
+            <Box sx={{ position: 'absolute', top: 115, left: '50%', transform: 'translateX(-50%)' }}>
                 <Box>
                     <Text
                         className="title"
-                        marginBottom="16px">Sent Requests
+                        marginBottom="16px"
+                    >
+                        Sent Requests
                     </Text>
                     <RequestsList
                         requests={sentRequests}
@@ -132,7 +134,9 @@ const Requests = () => {
                 <Box>
                     <Text
                         className="title"
-                        marginBottom="16px">Received Requests
+                        marginBottom="16px"
+                    >
+                        Received Requests
                     </Text>
                     <RequestsList
                         requests={receivedRequests}


### PR DESCRIPTION
<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
*  Repositioned text on Requests page


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Verify that titles appear with a margin below the nav bar
